### PR TITLE
[fix] - avoid rerender in house component

### DIFF
--- a/src/components/PicturesCarrousel.jsx
+++ b/src/components/PicturesCarrousel.jsx
@@ -1,20 +1,23 @@
-import { NavArrows } from "./NavArrows"
-import { useState } from "react"
-import "../styles/carrousel.css"
+import { NavArrows } from "./NavArrows";
+import { useState } from "react";
+import "../styles/carrousel.css";
 
-export function PicturesCarrousel ({house}) {
+export function PicturesCarrousel({ house }) {
+  const [picture, setPicture] = useState(1);
 
-    const [picture, setPicture] = useState(1)
-    
-    return <>
-        <div className="carrousel-wrapper">
-            <p>{`${picture}/${house.pictures.length}`}</p>
-            { 
-                house.pictures.length > 1 ? 
-                    <NavArrows pictures={house.pictures} picture={picture} setPicture={setPicture} /> :
-                    null
-            }
-            <img src={house.pictures[picture - 1]} alt={house.title} />
-        </div>
+  return (
+    <>
+      <div className="carrousel-wrapper">
+        <p>{`${picture}/${house.pictures.length}`}</p>
+        {house.pictures.length > 0 ? (
+          <NavArrows
+            pictures={house.pictures}
+            picture={picture}
+            setPicture={setPicture}
+          />
+        ) : null}
+        <img src={house.pictures[picture - 1]} alt={house.title} />
+      </div>
     </>
+  );
 }

--- a/src/components/Rating.jsx
+++ b/src/components/Rating.jsx
@@ -1,18 +1,16 @@
-import "../styles/house.css"
-import starActive from "../assets/star-active.svg"
-import starInactive from "../assets/star-inactive.svg"
+import "../styles/house.css";
+import starActive from "../assets/star-active.svg";
+import starInactive from "../assets/star-inactive.svg";
 
-export function Rating ({rating}) {
+export function Rating({ rating }) {
+  const ratingNumber = Number(rating);
+  const stars = [1, 2, 3, 4, 5];
 
-    const ratingNumber = Number(rating)
-    const stars = [1, 2, 3, 4, 5]
-    
-    stars.forEach( (e) => {
-        e > ratingNumber ? <img src={starActive} alt="active start" /> : <img src={starInactive} alt="disabled start"  />;
-    })
-
-    return stars.map( (e, i) => e <= ratingNumber ? 
-            <img src={starActive} alt="active start" key={`${e}-${i}`}/>
-            : <img src={starInactive} alt="disabled start" key={`${e}-${i}`} />
-        )
+  return stars.map((e, i) =>
+    e <= ratingNumber ? (
+      <img src={starActive} alt="active start" key={`${e}-${i}`} />
+    ) : (
+      <img src={starInactive} alt="disabled start" key={`${e}-${i}`} />
+    )
+  );
 }

--- a/src/components/Wrapper.jsx
+++ b/src/components/Wrapper.jsx
@@ -1,0 +1,3 @@
+export const Wrapper = ({ className, children }) => (
+  <div className={className}>{children}</div>
+);

--- a/src/pages/House.jsx
+++ b/src/pages/House.jsx
@@ -1,45 +1,49 @@
-import { useLoaderData, useParams } from "react-router-dom"
+import { useLoaderData, useParams } from "react-router-dom";
 
-import { PicturesCarrousel } from "../components/PicturesCarrousel"
+import { PicturesCarrousel } from "../components/PicturesCarrousel";
 import { Collapse } from "../components/Collapse";
 import { Title } from "../components/Title";
+import { Wrapper } from "../components/Wrapper";
 
 import { Host } from "../components/Host";
 import { Tags } from "../components/Tags";
 import { Rating } from "../components/Rating";
 
-import "../styles/house.css"
+import "../styles/house.css";
 
-export function House () {
-    
-    const {id} = useParams()
+export function House() {
+  const { id } = useParams();
 
-    const housing = useLoaderData()
-    const house = housing.find( e => e.id === id)
+  const housing = useLoaderData();
+  const house = housing.find((e) => e.id === id);
 
-    return <>
-            <div className="house-details">
-                <div className="house-carrousel">
-                    <PicturesCarrousel house={house}/>
-                </div>
-                <div className="house-title">
-                    <Title house={house} />
-                </div>
-                <div className="house-host">
-                    <Host house={house} />
-                </div>
-                <div className="house-tags">
-                    <Tags house={house} />
-                </div>
-                <div className="house-rating">
-                    <Rating rating={house.rating} />
-                </div>
-                <div className="house-description">
-                    { house.description && <Collapse title="description" content={house.description} /> }
-                </div>
-                <div className="house-equipments">
-                    { house.equipments && <Collapse title="equipments" content={house.equipments} /> }
-                </div>
-            </div>
-        </>
+  return (
+    <div className="house-details">
+      <Wrapper className="house-carrousel">
+        <PicturesCarrousel house={house} />
+      </Wrapper>
+      <Wrapper className="house-title">
+        <Title house={house} />
+      </Wrapper>
+      <Wrapper className="house-host">
+        <Host house={house} />
+      </Wrapper>
+      <Wrapper className="house-tags">
+        <Tags house={house} />
+      </Wrapper>
+      <Wrapper className="house-rating">
+        <Rating rating={house.rating} />
+      </Wrapper>
+      <Wrapper className="house-description">
+        {house.description && (
+          <Collapse title="description" content={house.description} />
+        )}
+      </Wrapper>
+      <Wrapper className="house-equipments">
+        {house.equipments && (
+          <Collapse title="equipments" content={house.equipments} />
+        )}
+      </Wrapper>
+    </div>
+  );
 }


### PR DESCRIPTION
Problème: La page House fait un rendu global de la page à chaque interaction de l'utilisateur.

Cause: Les composants sont tous wrappés par une div individuelle, cela casse la réconciliation des changements par composant de react.

Fix: 2 fix possible, refacto le code afin de d'intégrer les div aux composants ou les insérer dans un composant Wrapper en tant que children.

Cette PR propose le second choix. 

( Mon Prettier a remis en forme le style des composants modifiés, désolé)